### PR TITLE
Update Serilog reference

### DIFF
--- a/src/Serilog.Diagnostics.TraceListener/Serilog.Diagnostics.TraceListener.csproj
+++ b/src/Serilog.Diagnostics.TraceListener/Serilog.Diagnostics.TraceListener.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
I have an issue with one of my projects, and it fails to use this library when using a newer version of Serilog. So bumping the version referenced for Serilog would be helpful.